### PR TITLE
update node version to 8.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_FROM
 
 ENV LANG C.UTF-8
 
-RUN apk add --no-cache jq nodejs=8.9.1-r0 nodejs-npm && \
+RUN apk add --no-cache jq nodejs=8.9.3-r0 nodejs-npm && \
 npm set unsafe-perm true
 
 # Copy data for add-on


### PR DESCRIPTION
The latest homeassistant base image doesn't have node 8.9.1, only 8.9.3.