### PR TITLE
Add support for new modes: Fresh Air, Power Save, Lights, Health, Quiet, Sleep, Blow

### DIFF
--- a/app/commandEnums.js
+++ b/app/commandEnums.js
@@ -49,7 +49,8 @@ module.exports = {
         code: 'Air',
         value: {
             off: 0,
-            on: 1
+            on: 1,
+            both: 2 // guessed
         }
     },
     // "Blow" or "X-Fan", this function keeps the fan running for a while after shutting down. Only usable in Dry and Cool mode

--- a/app/commandEnums.js
+++ b/app/commandEnums.js
@@ -49,8 +49,8 @@ module.exports = {
         code: 'Air',
         value: {
             off: 0,
-            on: 1,
-            both: 2 // guessed
+            inside: 1,
+            outside: 2 // guessed
         }
     },
     // "Blow" or "X-Fan", this function keeps the fan running for a while after shutting down. Only usable in Dry and Cool mode

--- a/app/deviceFactory.js
+++ b/app/deviceFactory.js
@@ -148,7 +148,7 @@ class Device {
 
         // Extract encrypted package from message using device key (if available)
         const pack = encryptionService.decrypt(message, (this.device || {}).key);
-        
+
         // If package type is response to handshake
         if (pack.t === 'dev') {
             this._setDevice(message.cid, pack.name, rinfo.address, rinfo.port);
@@ -279,6 +279,54 @@ class Device {
         );
     };
     
+    setPowerSave (value) {
+        this._sendCommand(
+            [cmd.energySave.code],
+            [value ? 1 : 0]
+        )
+    };
+
+    setLights (value) {
+        this._sendCommand(
+            [cmd.lights.code],
+            [value ? 1 : 0]
+        )
+    };
+
+    setHealthMode (value) {
+        this._sendCommand(
+            [cmd.health.code],
+            [value ? 1 : 0]
+        );
+    }
+
+    setQuietMode (value) {
+        this._sendCommand(
+            [cmd.quiet.code],
+            [value ? 1 : 0]
+        )
+    };
+
+    setXFan (value) {
+        this._sendCommand(
+            [cmd.blow.code],
+            [value ? 1 : 0]
+        )
+    };
+
+    setFreshAir (value) {
+        this._sendCommand(
+            [cmd.airVale.code],
+            [value ? 1 : 0]
+        )
+    };
+
+    setSleepMode (value) {
+        this._sendCommand(
+            [cmd.sleep.code],
+            [value ? 1 : 0]
+        )
+    };
 };
 
 module.exports.connect = function(options) {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ const mqttTopicPrefix = argv['mqtt-topic-prefix'];
 const deviceOptions = {
   host: argv['hvac-host'],
   onStatus: (deviceModel) => {
-    console.debug(deviceModel);
     client.publish(mqttTopicPrefix + '/temperature/get', deviceModel.props[commands.temperature.code].toString());
     client.publish(mqttTopicPrefix + '/fanspeed/get', commands.fanSpeed.value.getKeyByValue(deviceModel.props[commands.fanSpeed.code]).toString());
     client.publish(mqttTopicPrefix + '/swingvert/get', commands.swingVert.value.getKeyByValue(deviceModel.props[commands.swingVert.code]).toString());

--- a/index.js
+++ b/index.js
@@ -28,10 +28,18 @@ const mqttTopicPrefix = argv['mqtt-topic-prefix'];
 const deviceOptions = {
   host: argv['hvac-host'],
   onStatus: (deviceModel) => {
+    console.debug(deviceModel);
     client.publish(mqttTopicPrefix + '/temperature/get', deviceModel.props[commands.temperature.code].toString());
     client.publish(mqttTopicPrefix + '/fanspeed/get', commands.fanSpeed.value.getKeyByValue(deviceModel.props[commands.fanSpeed.code]).toString());
     client.publish(mqttTopicPrefix + '/swingvert/get', commands.swingVert.value.getKeyByValue(deviceModel.props[commands.swingVert.code]).toString());
     client.publish(mqttTopicPrefix + '/power/get', commands.power.value.getKeyByValue(deviceModel.props[commands.power.code]).toString());
+    client.publish(mqttTopicPrefix + '/health/get', commands.health.value.getKeyByValue(deviceModel.props[commands.health.code]).toString());
+    client.publish(mqttTopicPrefix + '/powersave/get', commands.energySave.value.getKeyByValue(deviceModel.props[commands.energySave.code]).toString());
+    client.publish(mqttTopicPrefix + '/lights/get', commands.lights.value.getKeyByValue(deviceModel.props[commands.lights.code]).toString());
+    client.publish(mqttTopicPrefix + '/quiet/get', commands.quiet.value.getKeyByValue(deviceModel.props[commands.quiet.code]).toString());
+    client.publish(mqttTopicPrefix + '/xfan/get', commands.blow.value.getKeyByValue(deviceModel.props[commands.blow.code]).toString());
+    client.publish(mqttTopicPrefix + '/freshair/get', commands.airVale.value.getKeyByValue(deviceModel.props[commands.airVale.code]).toString());
+    client.publish(mqttTopicPrefix + '/sleep/get', commands.sleep.value.getKeyByValue(deviceModel.props[commands.sleep.code]).toString());
 
     /**
      * Handle "none" mode status
@@ -53,6 +61,13 @@ const deviceOptions = {
     client.subscribe(mqttTopicPrefix + '/fanspeed/set');
     client.subscribe(mqttTopicPrefix + '/swingvert/set');
     client.subscribe(mqttTopicPrefix + '/power/set');
+    client.subscribe(mqttTopicPrefix + '/health/set');
+    client.subscribe(mqttTopicPrefix + '/powersave/set');
+    client.subscribe(mqttTopicPrefix + '/lights/set');
+    client.subscribe(mqttTopicPrefix + '/quiet/set');
+    client.subscribe(mqttTopicPrefix + '/xfan/set');
+    client.subscribe(mqttTopicPrefix + '/freshair/set');
+    client.subscribe(mqttTopicPrefix + '/sleep/set');
   }
 };
 
@@ -95,6 +110,27 @@ client.on('message', (topic, message) => {
       return;
     case mqttTopicPrefix + '/power/set':
       hvac.setPower(parseInt(message));
+      return;
+    case mqttTopicPrefix + '/health/set':
+      hvac.setHealthMode(parseInt(message));
+      return;
+    case mqttTopicPrefix + '/powersave/set':
+      hvac.setPowerSave(parseInt(message));
+      return;
+    case mqttTopicPrefix + '/lights/set':
+      hvac.setLights(parseInt(message));
+      return;
+    case mqttTopicPrefix + '/quiet/set':
+      hvac.setQuietMode(parseInt(message));
+      return;
+    case mqttTopicPrefix + '/xfan/set':
+      hvac.setXFan(parseInt(message));
+      return;
+    case mqttTopicPrefix + '/freshair/set':
+      hvac.setFreshAir(parseInt(message));
+      return;
+    case mqttTopicPrefix + '/sleep/set':
+      hvac.setSleepMode(parseInt(message));
       return;
   }
   console.log('[MQTT] No handler for topic %s', topic)


### PR DESCRIPTION
Hi,

This pull request is adding support for `2` as state of "clean air valve" as my Gree U-Crown unit is reporting it currently. It seems to be the state for blowing the air outside. At least it is set to '2' when the small arrow on remote is poiting outside the house ;)

Also it exports additional modes and switches over MQTT, giving the ability to turn Air purifying or powersaving on or off.

I am going to use it with Home Assistants MQTT Buttons to regain control over plasma cleaner and powersave modes :)