### PR TITLE
New version 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ docker build \
 docker run --rm -v "$PWD/data":/data gree-hvac-mqtt-bridge
 ```
 
+### Run single device as a service
+
+To run it when the PC starts, a systemd service has to be created by following the following commands.
+
+```shell
+sudo cp /opt/gree-hvac-mqtt-bridge/gree-bridge.service /etc/systemd/system/gree-bridge.service
+sudo chmod +x /etc/systemd/system/gree-bridge.service
+sudo systemctl enable gree-bridge
+sudo systemctl start gree-bridge
+```
+
 ### Multiple devices
 
 As of 1.2.0 the Hassio addon supports multiple devices by running paralell NodeJS processes in PM2. Old configurations will work, but will run without PM2.
@@ -163,6 +174,7 @@ Note: This command may vary depending on your OS (e.g. Linux, macOS, CygWin). If
 [1.2.3]
 
 - Fix run script for single device with same configuration
+- Run single device as a systemd service
 
 [1.2.2]
 

--- a/README.md
+++ b/README.md
@@ -126,19 +126,9 @@ docker run --rm -v "$PWD/data":/data gree-hvac-mqtt-bridge
 
 ### Multiple devices
 
-As of 1.2.0 the Hassio addon supports multiple devices by running paralell NodeJS processes in PM2. Old configurations will work, but are deprecated.
+As of 1.2.0 the Hassio addon supports multiple devices by running paralell NodeJS processes in PM2. Old configurations will work, but will run without PM2.
 
-Deprecated config example:
-
-```json
-"hvac_host": "192.168.0.255",
-"mqtt": {
-    "broker_url": "mqtt://localhost",
-    "topic_prefix": "/my/topic/prefix",
-}
-```
-
-Correct config example:
+config example:
 
 ```json
 "mqtt": {
@@ -169,6 +159,10 @@ echo -n "{\"psw\": \"YOUR_WIFI_PASSWORD\",\"ssid\": \"YOUR_WIFI_SSID\",\"t\": \"
 Note: This command may vary depending on your OS (e.g. Linux, macOS, CygWin). If facing problems, please consult the appropriate netcat manual.
 
 ## Changelog
+
+[1.2.3]
+
+- Fix run script for single device with same configuration
 
 [1.2.2]
 

--- a/README.md
+++ b/README.md
@@ -142,19 +142,24 @@ As of 1.2.0 the Hassio addon supports multiple devices by running paralell NodeJ
 config example:
 
 ```json
-"mqtt": {
-    "broker_url": "mqtt://localhost",
-},
-"devices": [
-  {
-    "hvac_host": "192.168.0.255",
-    "mqtt_topic_prefix": "/home/hvac01"
-  },
-  {
-    "hvac_host": "192.168.0.254",
-    "mqtt_topic_prefix": "/home/hvac02"
-  }
-]
+{
+    "mqtt": {
+        "broker_url": "mqtt://localhost",
+        "username": "user",
+        "password": "pass",
+	"retain": false
+    },
+    "devices": [
+      {
+        "hvac_host": "192.168.0.255",
+        "mqtt_topic_prefix": "/home/hvac01"
+      },
+      {
+        "hvac_host": "192.168.0.254",
+        "mqtt_topic_prefix": "/home/hvac02"
+      }
+    ]
+}
 ```
 
 ## Configuring HVAC WiFi
@@ -175,6 +180,7 @@ Note: This command may vary depending on your OS (e.g. Linux, macOS, CygWin). If
 
 - Fix run script for single device with same configuration
 - Run single device as a systemd service
+- Add option to MQTT for retain flag
 
 [1.2.2]
 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Gree HVAC MQTT bridge",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "slug": "gree_hvac_mqtt_bridge",
     "description": "Hass.io addon for controlling Gree air conditioners using the MQTT climate platform",
     "arch": [ "aarch64", "amd64", "armhf", "armv7", "i386" ],
@@ -12,7 +12,8 @@
         "mqtt": {
             "broker_url": "mqtt://localhost",
             "username": "",
-            "password": ""
+            "password": "",
+            "retain": ""
         },
         "devices": [
             {
@@ -27,7 +28,8 @@
             "broker_url": "str",
             "topic_prefix": "str?",
             "username": "str?",
-            "password": "str?"
+            "password": "str?",
+            "retain": "str?"
         },
         "devices": [
             {

--- a/gree-bridge.service
+++ b/gree-bridge.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Gree HVAC MQTT Bridge
+After=network.target
+
+[Service]
+User=root
+WorkingDirectory=/opt/gree-hvac-mqtt-bridge
+ExecStart=/opt/gree-hvac-mqtt-bridge/run.sh
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+

--- a/index.js
+++ b/index.js
@@ -45,9 +45,15 @@ const deviceState = {
  * @param {string} mqttTopic Topic (without prefix) to send with new value
  */
 const publishIfChanged = function (stateProp, newValue, mqttTopic) {
+  const pubmqttOptions = {
+    retain: false
+  }
+  if (argv['mqtt-retain']) {
+    pubmqttOptions.retain = (argv['mqtt-retain'] == "true")
+  }
   if (newValue !== deviceState[stateProp]) {
     deviceState[stateProp] = newValue
-    client.publish(mqttTopicPrefix + mqttTopic, newValue)
+    client.publish(mqttTopicPrefix + mqttTopic, newValue, pubmqttOptions)
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1587,7 +1587,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1605,11 +1606,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1622,15 +1625,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1733,7 +1739,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1743,6 +1750,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1755,17 +1763,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1782,6 +1793,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1854,7 +1866,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1864,6 +1877,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1939,7 +1953,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1969,6 +1984,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1986,6 +2002,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2024,11 +2041,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gree-hvac-mqtt-bridge",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gree-hvac-mqtt-bridge",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "MQTT Bridge for controlling Gree smart air conditioners",
   "main": "index.js",
   "scripts": {

--- a/run.sh
+++ b/run.sh
@@ -13,7 +13,7 @@ npm install
 
 INSTANCES=$(jq '.devices | length' $CONFIG_PATH)
 
-if [ "$INSTANCES" -gt 0 ]; then
+if [ "$INSTANCES" -gt 1 ]; then
 	for i in $(seq 0 $(($INSTANCES - 1))); do
 		HVAC_HOST=$(jq -r ".devices[$i].hvac_host" $CONFIG_PATH);
 		MQTT_TOPIC_PREFIX=$(jq -r ".devices[$i].mqtt_topic_prefix" $CONFIG_PATH);
@@ -31,7 +31,7 @@ if [ "$INSTANCES" -gt 0 ]; then
 else
 	HVAC_HOST=$(jq -r ".devices[0].hvac_host" $CONFIG_PATH);
 	MQTT_TOPIC_PREFIX=$(jq -r ".devices[0].mqtt_topic_prefix" $CONFIG_PATH);
-	echo "Running instance 0 for $HVAC_HOST"
+	echo "Running single instance for $HVAC_HOST"
 	#echo "${HVAC_HOST}, ${MQTT_BROKER_URL}, ${MQTT_TOPIC_PREFIX}, ${MQTT_USERNAME}, ${MQTT_PASSWORD}"
 	/usr/bin/node index.js \
 		--hvac-host="${HVAC_HOST}" \

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-CONFIG_PATH=/data/options.json
+CONFIG_PATH=data/options.json
 
 HVAC_HOST=$(jq -r ".hvac_host" $CONFIG_PATH)
 MQTT_BROKER_URL=$(jq -r ".mqtt.broker_url" $CONFIG_PATH)
@@ -29,8 +29,11 @@ if [ "$INSTANCES" -gt 0 ]; then
 	done
 	npx pm2 logs /HVAC_/
 else
-	echo "Running in single-instance mode (DEPRECATED)"
-	node index.js \
+	HVAC_HOST=$(jq -r ".devices[0].hvac_host" $CONFIG_PATH);
+	MQTT_TOPIC_PREFIX=$(jq -r ".devices[0].mqtt_topic_prefix" $CONFIG_PATH);
+	echo "Running instance 0 for $HVAC_HOST"
+	#echo "${HVAC_HOST}, ${MQTT_BROKER_URL}, ${MQTT_TOPIC_PREFIX}, ${MQTT_USERNAME}, ${MQTT_PASSWORD}"
+	/usr/bin/node index.js \
 		--hvac-host="${HVAC_HOST}" \
 		--mqtt-broker-url="${MQTT_BROKER_URL}" \
 		--mqtt-topic-prefix="${MQTT_TOPIC_PREFIX}" \

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,12 @@ MQTT_BROKER_URL=$(jq -r ".mqtt.broker_url" $CONFIG_PATH)
 MQTT_TOPIC_PREFIX=$(jq -r ".mqtt.topic_prefix" $CONFIG_PATH)
 MQTT_USERNAME=$(jq -r ".mqtt.username" $CONFIG_PATH)
 MQTT_PASSWORD=$(jq -r ".mqtt.password" $CONFIG_PATH)
+MQTT_RETAIN=$(jq -r ".mqtt.retain" $CONFIG_PATH)
+if [ "$MQTT_RETAIN" = null ]; then
+  MQTT_RETAIN=false
+fi
 
+echo "MQTT_RETAIN: ${MQTT_RETAIN}"
 npm install
 
 INSTANCES=$(jq '.devices | length' $CONFIG_PATH)
@@ -25,7 +30,8 @@ if [ "$INSTANCES" -gt 1 ]; then
 			--mqtt-broker-url="${MQTT_BROKER_URL}" \
 			--mqtt-topic-prefix="${MQTT_TOPIC_PREFIX}" \
 			--mqtt-username="${MQTT_USERNAME}" \
-			--mqtt-password="${MQTT_PASSWORD}"
+			--mqtt-password="${MQTT_PASSWORD}" \
+			--mqtt-retain="${MQTT_RETAIN}"
 	done
 	npx pm2 logs /HVAC_/
 else
@@ -38,5 +44,6 @@ else
 		--mqtt-broker-url="${MQTT_BROKER_URL}" \
 		--mqtt-topic-prefix="${MQTT_TOPIC_PREFIX}" \
 		--mqtt-username="${MQTT_USERNAME}" \
-		--mqtt-password="${MQTT_PASSWORD}"
+		--mqtt-password="${MQTT_PASSWORD}" \
+		--mqtt-retain="${MQTT_RETAIN}"
 fi


### PR DESCRIPTION
I've updated the version to 1.2.3 with some changes:

- Changed the way the application runs with a single device to match the config from multiple devices. If it is one device it runs without PM2.
- Added systemd service with instructions on how to implement it for use for single devices.
- Added option to retain the mqtt message from the configuration file.